### PR TITLE
Only allow remote API functions to be called directly from client.

### DIFF
--- a/HISTORY.md
+++ b/HISTORY.md
@@ -1,3 +1,5 @@
+## 2.5.1
+* only allow on server functions to be called directly from the client
 ## 2.5.0
 * Adding the string of all the changes performed in a server call as parameter in the postServerCall callback
 ## 2.4.1

--- a/index.js
+++ b/index.js
@@ -2673,8 +2673,13 @@ RemoteObjectTemplate.bindDecorators = function (objectTemplate) {
             defineProperty.on = 'server';
         }
         return function (target, propertyName, descriptor) {
-            descriptor.value  = objectTemplate._setupFunction(propertyName, descriptor.value,
+            descriptor.value = objectTemplate._setupFunction(propertyName, descriptor.value,
                 defineProperty.on, defineProperty.validate);
+
+            if (!descriptor.value.__on__) {
+                descriptor.value.__on__ = 'server';
+            }
+
             if (defineProperty.type) {
                 descriptor.value.__returns__ = defineProperty.type;
             }

--- a/index.js
+++ b/index.js
@@ -2669,6 +2669,11 @@ RemoteObjectTemplate.bindDecorators = function (objectTemplate) {
 
     this.remote = function (defineProperty) {
         defineProperty = defineProperty || {};
+
+        /*
+            if we haven't supplied a configuration object into the decorator,
+             default the role of this function to a server API function
+         */
         if (!defineProperty.on) {
             defineProperty.on = 'server';
         }
@@ -2676,7 +2681,11 @@ RemoteObjectTemplate.bindDecorators = function (objectTemplate) {
             descriptor.value = objectTemplate._setupFunction(propertyName, descriptor.value,
                 defineProperty.on, defineProperty.validate);
 
-            if (!descriptor.value.__on__) {
+            /*
+                this function been marked as a server API either explicitly or by default.
+                set the appropriate metadata.
+             */
+            if (defineProperty.on === 'server') {
                 descriptor.value.__on__ = 'server';
             }
 

--- a/index.js
+++ b/index.js
@@ -487,19 +487,23 @@ RemoteObjectTemplate.processMessage = function processMessage(remoteCall, subscr
 
         let changes = JSON.parse(remoteCall.changes);
 
-        if (this._applyChanges(changes, this.role == 'client', subscriptionId, callContext)) {
+        if (this._applyChanges(changes, this.role === 'client', subscriptionId, callContext)) {
             const obj = session.objects[remoteCall.id];
 
             if (!obj) {
                 throw new Error('Cannot find object for remote call ' + remoteCall.id);
             }
 
-            if (this.role == 'server' && obj['validateServerCall']) {
+            // check to see if this function is supposed to be called directly from client
+            if (obj.__proto__[remoteCall.name].__on__ !== 'server') {
+                throw 'Invalid Function Call; not an API function';
+            }
+
+            if (this.role === 'server' && obj['validateServerCall']) {
                 return obj['validateServerCall'].call(obj, remoteCall.name, callContext);
             }
-            else {
-                return true;
-            }
+
+            return true;
         }
         else {
             throw 'Sync Error';

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
     "name": "semotus",
-    "version": "2.5.0",
+    "version": "2.5.1",
     "lockfileVersion": 1,
     "requires": true,
     "dependencies": {

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
     "name": "semotus",
     "description": "A subclass of supertype that synchronizes sets of objects.",
     "homepage": "https://github.com/selsamman/semotus",
-    "version": "2.5.0",
+    "version": "2.5.1",
     "dependencies": {
         "q": "1.x",
         "supertype": "3.1.*"


### PR DESCRIPTION
How this was accomplished: 
1. Put a special meta property on functions decorated with `@remote` that denotes the function as an API function. 
2. check for that meta property before executing the call. if it's there, proceed normally. if it's not, throw a specific error message.